### PR TITLE
Fixed global `type` in ftpParser.js

### DIFF
--- a/lib/ftpParser.js
+++ b/lib/ftpParser.js
@@ -209,6 +209,7 @@ var parsers = {
     },
     msdos: function(entry) {
         var group = entry.match(RE_DOSEntry);
+        var type;
 
         if (group) {
             var replacer = function replacer(str, hour, min, ampm, offset, s) {


### PR DESCRIPTION
After introducing "use strict" we assumed that all globals would be
found on compile time, so after passing all tests I assumed that ftp
would be fine. Apparently, strict mode detects globals on runtime and
msdos was leaking the `type` global, making c9 behave erratically. It
is declared now.
