### PR TITLE
See Below

### DIFF
--- a/jsftp_test.js
+++ b/jsftp_test.js
@@ -138,10 +138,13 @@ module.exports = {
                 });
 
                 ftp.raw.cwd("/unexistentDir/", function(err, res) {
-                    assert.ok(err);
-
-                    code = parseInt(res.code, 10);
-                    assert.ok(code === 550, "A (wrong) CWD command was successful. It should have failed");
+                	  if (err)
+                	  	  assert.ok(err);
+                	  else {
+                        code = parseInt(res.code, 10);
+                        assert.ok(code === 550, "A (wrong) CWD command was successful. It should have failed");
+                	  }
+                	  
                     next();
                 });
             });

--- a/lib/ftpParser.js
+++ b/lib/ftpParser.js
@@ -44,7 +44,7 @@ var RE_UnixEntry = new RegExp(
 
     // year (for non-recent standard format)
     // or time (for numeric or recent standard format)
-    + "(\\d+(?::\\d+)?)\\s+"
+    + "(\\d+(?::\\d+)?)\\s?"
 
     //+ "(\\S*)(\\s*.*)"
     + "(.*)"
@@ -57,7 +57,7 @@ var RE_UnixEntry = new RegExp(
 var RE_DOSEntry = new RegExp(
     "(\\S+)\\s+(\\S+)\\s+"
     + "(<DIR>)?\\s*"
-    + "([0-9]+)?\\s+"
+    + "([0-9]+)?\\s?"
     + "(\\S.*)"
 );
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "web": "https://github.com/sergi/jsftp/issues"
   },
   "dependencies": {
-    "streamer": "=0.0.4"
+    "streamer": "0.2.x"
   },
   "devDependencies": {
     "asyncjs": ">=0.0.5"


### PR DESCRIPTION
- Throw Errors not strings [see here](www.devthought.com/2011/12/22/a-string-is-not-an-error/)
- Check for 200 user auth error
- Fix Test case #2, allow for error OR res.code === 550, not both
- Allow leading spaces in filenames
- Fix invalid dependency semver for streamer
