### PR TITLE
Removing reference to non-existing variable

### DIFF
--- a/jsftp.js
+++ b/jsftp.js
@@ -173,7 +173,7 @@ var Ftp = module.exports = function(cfg) {
 
                 var reConnect = function() {
                     self.connecting = false;
-                    !err && send();
+                    send();
                 };
 
                 try {


### PR DESCRIPTION
The "push" command references a non-existing "err" variable in the "reConnect" method (if the socket is not writeable).
