### PR TITLE
Implement proper streaming capabilities for passive commands

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -60,7 +60,7 @@ var Ftp = module.exports = function(cfg) {
     if (DEBUG_MODE) {
         var self = this;
         ["command", "response", "connect", "reconnect", "disconnect"].forEach(function(event) {
-            self.emitter.on(event, self.log);
+            self.emitter.on(event, console.log);
         });
     }
 
@@ -487,67 +487,6 @@ Ftp.getPasvPort = function(text) {
     };
 
     /**
-     * Tells the server to enter passive mode, in which the server returns
-     * a data port where we can listen to passive data. The callback is called
-     * when the passive socket closes its connection.
-     *
-     * @param callback {function}: Function to execute when the data socket closes (either by success or by error).
-     */
-    this.getPassiveSocket = function(callback) {
-        var self = this;
-
-        // `_getPassive` retrieves a passive connection and sends its socket to
-        // the callback.
-        var _getPassive = function _getPassive(callback) {
-            var doPasv = function(err, res) {
-                if (err || !res || res.code !== 227) {
-                    if (res && res.text)
-                        return callback(new Error(res.text));
-                    else if (err)
-                        return callback(err);
-                    else
-                        return callback(new Error("Unknown error when trying to get into PASV mode"));
-                }
-
-                // Executes the next passive call, if there are any.
-                var nextPasv = function nextPasv(err) {
-                    self.currentPasv = null;
-                    if (self.pasvCallBuffer.length) {
-                        self.currentPasv = self.pasvCallBuffer.shift();
-                        self.currentPasv(callback);
-                    }
-                };
-
-                var port = Ftp.getPasvPort(res.text);
-                if (port === false) return callback(new Error("PASV: Bad port"));
-
-                var socket = Net.createConnection(port, self.host);
-                // On each one of the events below we want to move on to the
-                // next passive call, if any.
-                socket.on("close", nextPasv);
-
-                // Send the passive socket to the callback.
-                callback(null, socket);
-            };
-
-            self.raw.type("I", function() { self.enqueue(["pasv", doPasv]); });
-        };
-
-        // If there is a passive call happening, we put the requested passive
-        // call in the passive call buffer, to be executed later.
-        var fn = function() { _getPassive(callback); };
-        if (this.currentPasv) {
-            this.pasvCallBuffer.push(fn);
-        }
-        // otherwise, execute right away because there is no passive calls
-        // occuring right now.
-        else {
-            this.currentPasv = fn;
-            this.currentPasv(callback);
-        }
-    };
-
-    /**
      * Lists a folder's contents using a passive connection.
      *
      * @param filePath {String} Remote file/folder path
@@ -558,67 +497,116 @@ Ftp.getPasvPort = function(text) {
             filePath = "";
         }
 
-        var self = this;
-        this.getPassiveSocket(function(err, socket) {
-            if (err) return callback(err);
-
-            concatStream(null, socket, callback);
-            self.enqueue(["list " + filePath]);
-        });
+        this.orderedPasv({
+            cmd: ["list " + filePath],
+            concat: true
+        }, callback);
     };
 
     this.get = function(filePath, callback) {
-        var self = this;
-        this.getPassiveSocket(function(err, socket) {
-            if (err) return callback(err);
-
-            concatStream(null, socket, callback);
-            self.enqueue(["retr " + filePath]);
-        });
+        this.orderedPasv({
+            cmd: ["retr " + filePath],
+            concat: true
+        }, callback);
     };
 
     this.getGetSocket = function(path, callback) {
-        var self = this;
-        this.getPassiveSocket(function(err, socket) {
-            if (err) return callback(err);
-            // Pause the socket to avoid data streaming before there are any
-            // listeners to it. We'll let the API consumer resume it.
-            if (socket.pause)
-                socket.pause();
-
-            callback(null, socket);
-            self.enqueue(["retr " + path]);
-        });
+        this._streamingPasv(["retr " + path], callback);
     };
 
-    this.put = function(filepath, buffer, callback) {
-        var self = this;
-        this.getPassiveSocket(function(err, socket) {
+    this.put = function(filePath, buffer, callback) {
+        this.orderedPasv({ cmd: ["stor " + filePath] }, function(err, socket) {
             if (err) return callback(err);
 
-            self.enqueue(["stor " + filepath]);
             setTimeout(function() {
                 if (socket && socket.writable) {
                     socket.end(buffer);
                     callback(null, buffer);
                 }
                 else {
-                    console.log("ftp error: couldn't retrieve pasv connection for command 'stor " + filepath + "'.");
+                    console.log("ftp error: couldn't retrieve connection for 'stor " + filePath + "'.");
                 }
             }, 100);
         });
     };
 
     this.getPutSocket = function(filepath, callback) {
-        var self = this;
-        this.getPassiveSocket(function(err, socket) {
-            if (err) return callback(err);
-            self.enqueue(["stor " + filepath]);
-            setTimeout(function() {
-                callback(null, socket);
-            }, 100);
-        });
+        this._streamingPasv(["stor " + filepath], callback);
     };
+
+    this._streamingPasv = function(cmd, callback) {
+        var self = this;
+        var doPasv = function(err, res) {
+            if (err || !res || res.code !== 227) {
+                if (res && res.text)
+                    return callback(new Error(res.text));
+                else if (err)
+                    return callback(err);
+                else
+                    return callback(new Error("Unknown error when trying to get into PASV mode"));
+            }
+
+            var port = Ftp.getPasvPort(res.text);
+            if (port === false)
+                return callback(new Error("PASV: Bad port"));
+
+            // Send the passive socket to the callback.
+            callback(null, Net.createConnection(port, self.host));
+            self.enqueue(cmd);
+        };
+        self.raw.type("I", function() { self.enqueue(["pasv", doPasv]); });
+    };
+    
+    /**
+     * Sequential passive mode. When this function is used on a command, it will
+     * wait until the current command is executed, and then it will proceed to 
+     * execute the next command in the queue.
+     * 
+     * The options object contains two options:
+     *  - options.cmd: is an array containing the command string e.g. ["stor " + filePath]
+     *  - options.concat: Whether the result of the operation should be concatenated 
+     * and delivered to the allback when finished.
+     *
+     * @param options {Object}: Contains the options for this function
+     * @param callback {Function}: Function to execute when the data socket closes (either by success or by error).
+     */
+    this.orderedPasv = function(options, callback) {
+        var self = this;
+        // If there is a passive call happening, we put the requested passive
+        // call in the passive call buffer, to be executed later.
+        var fn = function() {
+            this._streamingPasv(options.cmd, function(err, socket) {
+                if (err) return callback(err);
+
+                // Executes the next passive call, if there are any.
+                var nextPasv = function nextPasv(err) {
+                    self.currentPasv = null;
+                    if (self.pasvCallBuffer.length) {
+                        self.currentPasv = self.pasvCallBuffer.shift();
+                        self.currentPasv(callback);
+                    }
+                };
+
+                // On each one of the events below we want to move on to the
+                // next passive call, if any.
+                socket.on("close", nextPasv);
+                if (options.concat)
+                    concatStream(err, socket, callback);
+                else
+                    callback(err, socket);
+            });
+        };
+
+        if (this.currentPasv) {
+            this.pasvCallBuffer.push(fn);
+        }
+        // otherwise, execute right away because there are no passive calls
+        // happening right now.
+        else {
+            this.currentPasv = fn;
+            this.currentPasv();
+        }
+    },
 
     /**
      * Provides information about files. It lists a directory contents or


### PR DESCRIPTION
This fix gives proper Nodejs streaming capabilities to FTP. Until now, jsftp relied on buffering, although it had streaming methods ready to be used (`getPutSocket` and `getGetSocket`). However, upon some testing with vfs-ftp I found out that piping wouldn't work, and it would never do because of the way that PASV commands were handled at the moment. That is, sequentially.

Passive command handling methods have been now split into two, `_streamingPasv` and `orderedPasv`. The latter uses the former, and now the user of the API can choose what API to use (the streaming API is less straightforward). In this way, `getPutSocket` and `getGetSocket` can directly use the methods that allow them to do multiple requests and deal with the returned sockets (streams). The implementation is cleaner now.

In case you were wondering why not get rid of the sequential API, it is because the sequential API is useful for when the user wants to ensure that an FTP command will always be executed after another. Check out the test `"test multiple concurrent pasvs"` as an example.

@ajaxorg/knuth @zefhemel  
