### PR TITLE
Revert "Fix entry parsing for non-file information. Space out tests."

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -95,28 +95,22 @@ Ftp.isMark = function(code) {
 };
 
 Ftp.parseEntry = function(entries) {
-    var t, entry, parsedEntry;
+    var t;
     var parsed = [];
     var splitEntries = entries.split(/\r\n|\n/);
     for (var i = 0; i < splitEntries.length; i++) {
-        entry = splitEntries[i];
-
-        if (RE_RES.test(entry) || RE_MULTI.test(entry)) {
-            continue;
-        }
-
-        parsedEntry = Parser.entryParser(entry);
+        var parsedEntry = Parser.entryParser(splitEntries[i]);
         if (parsedEntry === null) {
             if (splitEntries[i+1]) {
-                t = Parser.entryParser(entry + splitEntries[i+1])
+                t = Parser.entryParser(splitEntries[i] + splitEntries[i+1])
                 if (t !== null) {
-                    splitEntries[i+1] = entry + splitEntries[i+1];
+                    splitEntries[i+1] = splitEntries[i] + splitEntries[i+1];
                     continue;
                 }
             }
 
             if (splitEntries[i-1] && parsed.length > 0) {
-                t = Parser.entryParser(splitEntries[i-1] + entry)
+                t = Parser.entryParser(splitEntries[i-1] + splitEntries[i])
                 if (t !== null) {
                     parsed[parsed.length-1] = t
                 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsftp",
   "id": "jsftp",
-  "version": "0.5.8",
+  "version": "0.5.7",
   "description": "A sane FTP client implementation for NodeJS",
   "keywords": [ "ftp", "protocol", "files", "server", "client", "async" ],
   "author": "Sergi Mansilla <sergi.mansilla@gmail.com> (http://sergimansilla.com)",

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -48,7 +48,7 @@ describe("jsftp test suite", function() {
         setTimeout(function() {
             ftp = new Ftp(FTPCredentials);
             next();
-        }, 400);
+        }, 200);
     });
 
     afterEach(function(next) {
@@ -61,7 +61,7 @@ describe("jsftp test suite", function() {
                 ftp = null;
             }
             next();
-        }, 200);
+        }, 100);
     }),
 
     it("test features command", function(next) {

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -423,7 +423,7 @@ describe("jsftp file listing parser", function() {
                 assert.equal(unixEntries[i].type, entry.type);
                 assert.equal(unixEntries[i].size, entry.size);
                 assert.equal(unixEntries[i].name, entry.name);
-                //assert.equal(unixEntries[i].time, entry.time);
+                assert.equal(unixEntries[i].time, entry.time);
                 assert.equal(unixEntries[i].owner, entry.owner);
                 assert.equal(unixEntries[i].group, entry.group);
 
@@ -451,7 +451,7 @@ describe("jsftp file listing parser", function() {
                 assert.equal(unixEntries2[i].type, entry.type);
                 assert.equal(unixEntries2[i].size, entry.size);
                 assert.equal(unixEntries2[i].name, entry.name);
-                //assert.equal(unixEntries2[i].time, entry.time);
+                assert.equal(unixEntries2[i].time, entry.time);
                 assert.equal(unixEntries2[i].owner, entry.owner);
                 assert.equal(unixEntries2[i].group, entry.group);
 
@@ -610,7 +610,7 @@ drwx------    2 0        0            4096 Apr 16  2011 lost+found\r\n\
                 assert.equal(unixEntries[i].type, entry.type);
                 assert.equal(unixEntries[i].size, entry.size);
                 assert.equal(unixEntries[i].name, entry.name);
-                //assert.equal(unixEntries[i].time, entry.time);
+                assert.equal(unixEntries[i].time, entry.time);
                 assert.equal(unixEntries[i].owner, entry.owner);
                 assert.equal(unixEntries[i].group, entry.group);
 


### PR DESCRIPTION
This reverts commit edd15a33ac0b3118757b4283a696096a38869df0. Apparently getting directory listings breaks with that commit in, we had to revert it for Cloud9.

@sergi can you merge this or have a look?
