### PR TITLE
Added Chunk Size to Ftp.prototype.emitProgress

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -389,6 +389,7 @@ Ftp.prototype.emitProgress = function(data) {
     filename: data.filename,
     action: data.action,
     total: data.totalSize || 0,
+    chunksize: data.socket['_readableState'].length,
     transferred: data.socket[
       data.action === 'get' ? 'bytesRead' : 'bytesWritten']
   });


### PR DESCRIPTION
As mentioned in #53 - progress for writing files works for me after this change.  Don't know if it's the most elegant solution, but at least it works. On each progress-event "chunksize" represents the data sent since last event. So it's NOT the total data.  