### PR TITLE
Fix breakage where servers return 125: Data connection already open

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -442,7 +442,7 @@ Ftp.prototype.getGetSocket = function(path, callback) {
     function cmdCallback(err, res) {
       if (err) return callback(err);
 
-      if (res.code === 150)
+      if (res.code === 125 || res.code === 150)
         callback(null, socket);
       else
         callback(new Error("Unexpected command " + res.text));
@@ -515,7 +515,7 @@ Ftp.prototype.getPutSocket = function(path, callback, doneCallback) {
 
       // Mark 150 indicates that the 'STOR' socket is ready to receive data.
       // Anything else is not relevant.
-      if (res.code === 150) {
+      if (res.code === 125 || res.code === 150) {
         socket.on('close', doneCallback);
         socket.on('error', doneCallback);
         _callback(null, socket);


### PR DESCRIPTION
While trying to put files to the server I'm getting the following error: "[Error: Unexpected command 125 Data connection already open; Transfer starting.]"

It looks like cmdCallback is expecting code 150, whereas my server is sending 125. These should probably both be acceptable, and this code seems to work on the servers I've tested it with.
