### PR TITLE
Add ftp-response-parser to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "event-stream": "~3.0.14",
     "parse-listing": "~1.1.0",
-    "once": "~1.3.0"
+    "once": "~1.3.0",
+    "ftp-response-parser": "~1.1.0"
   },
   "devDependencies": {
     "mocha": "~1.10.0",


### PR DESCRIPTION
Without ftp-response-parser installed, jsftp client fails. See https://github.com/sergi/jsftp/issues/68 .
