### PR TITLE
Accept stream.Read as a source parameter to put

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -456,36 +456,43 @@ Ftp.prototype.getGetSocket = function(path, callback) {
  * @param {Function} callback Function to execute on error or success.
  */
 Ftp.prototype.put = function(from, to, callback) {
+  var self = this;
+
+  function putReadable(from, to, totalSize, callback) {
+    from.on("readable", function() {
+      self.emitProgress({
+        filename: to,
+        action: "put",
+        socket: from,
+        totalSize: totalSize
+      });
+    });
+
+    self.getPutSocket(to, function(err, socket) {
+      if (err) return;
+      from.pipe(socket);
+    }, callback);
+  }
+
   if (from instanceof Buffer) {
     this.getPutSocket(to, function(err, socket) {
       if (!err) socket.end(from);
     }, callback);
-  } else {
-    var self = this;
+  } else if (typeof from === "string" || from instanceof String) {
     fs.exists(from, function(exists) {
       if (!exists)
         return callback(new Error("Local file doesn't exist."));
 
-      self.getPutSocket(to, function(err, socket) {
-        if (err) return;
-
-        fs.stat(from, function(err, stats) {
+      fs.stat(from, function(err, stats) {
           var totalSize = err ? 0 : stats.size;
           var read = fs.createReadStream(from, {
             bufferSize: 4 * 1024
           });
-          read.pipe(socket);
-          read.on('readable', function() {
-            self.emitProgress({
-              filename: to,
-              action: 'put',
-              socket: read,
-              totalSize: totalSize
-            });
-          });
-        });
-      }, callback);
+          putReadable(read, to, totalSize, callback);
+      });
     });
+  } else {
+    putReadable(from, to, from.size, callback);
   }
 };
 

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -362,6 +362,26 @@ describe("jsftp test suite", function() {
     });
   });
 
+  it("test streaming put", function(next) {
+    var readStream = Fs.createReadStream(__filename);
+    var remoteFileName = "file_ftp_test.txt";
+    var filePath = getRemotePath(remoteFileName);
+    ftp.put(readStream, filePath, function(hadError) {
+      assert.ok(!hadError);
+
+      ftp.ls(filePath, function(err, res) {
+        assert.ok(!err);
+        assert.equal(res[0].size, Fs.statSync(CWD + "/jsftp_test.js").size);
+
+        ftp.raw.dele(filePath, function(err, data) {
+          assert.ok(!err);
+
+          next();
+        });
+      });
+    });
+  });
+
   it("test rename a file", function(next) {
     var from = getRemotePath("file_ftp_test.txt");
     var to = getRemotePath("file_ftp_test_renamed.txt");


### PR DESCRIPTION
Hello,

I have a requirement not to create temporary files or buffer entire file contents when uploading to FTP from HTTP mulitpart POST. I have updated put function so it accepts `stream.Read` as a source. I thought it might be useful to others as well.

Cheers,
Dali
