### PR TITLE
allow request chaining

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -52,6 +52,7 @@ function runCmd(cmd) {
     completeCmd += " " + args.join(" ");
   }
   this.execute(completeCmd.trim(), callback);
+  return this;
 }
 
 var Ftp = module.exports = function(cfg) {
@@ -265,6 +266,7 @@ Ftp.prototype.getFeatures = function(callback) {
       callback(null, self.features);
     });
   });
+  return this;
 };
 
 /**
@@ -273,6 +275,7 @@ Ftp.prototype.getFeatures = function(callback) {
  * @param user {String} Username
  * @param pass {String} Password
  * @param callback {Function} Follow-up function.
+ * @return {Ftp} this
  */
 Ftp.prototype.auth = function(user, pass, callback) {
   this.pending.push(callback);
@@ -285,7 +288,7 @@ Ftp.prototype.auth = function(user, pass, callback) {
       cb(err, res);
   }
 
-  if (this.authenticating) return;
+  if (this.authenticating) return this;
 
   if (!user) user = "anonymous";
   if (!pass) pass = "@anonymous";
@@ -314,6 +317,7 @@ Ftp.prototype.auth = function(user, pass, callback) {
       notifyAll(err);
     }
   });
+  return this;
 };
 
 Ftp.prototype.setType = function(type, callback) {
@@ -326,6 +330,7 @@ Ftp.prototype.setType = function(type, callback) {
 
     callback(err, data);
   });
+  return this;
 };
 
 /**
@@ -333,6 +338,7 @@ Ftp.prototype.setType = function(type, callback) {
  *
  * @param {String} [path] Remote path for the file/folder to retrieve
  * @param {Function} callback Function to call with errors or results
+ * @return {Ftp} this
  */
 Ftp.prototype.list = function(path, callback) {
   if (arguments.length === 1) {
@@ -365,6 +371,7 @@ Ftp.prototype.list = function(path, callback) {
       self.send("list " + (path || ""));
     });
   });
+  return this;
 };
 
 Ftp.prototype.emitProgress = function(data) {
@@ -375,6 +382,7 @@ Ftp.prototype.emitProgress = function(data) {
     transferred: data.socket[
       data.action === 'get' ? 'bytesRead' : 'bytesWritten']
   });
+  return this;
 };
 
 /**
@@ -386,6 +394,7 @@ Ftp.prototype.emitProgress = function(data) {
  * @param {String} remotePath File to be retrieved from the FTP server
  * @param {String} localPath Local path where the new file will be created
  * @param {Function} [callback] Gets called on either success or failure
+ * @return {Ftp} this
  */
 Ftp.prototype.get = function(remotePath, localPath, callback) {
   var self = this;
@@ -414,6 +423,7 @@ Ftp.prototype.get = function(remotePath, localPath, callback) {
       socket.resume();
     })
   }
+  return this;
 };
 
 /**
@@ -423,6 +433,7 @@ Ftp.prototype.get = function(remotePath, localPath, callback) {
  *
  * @param path {String} Path to the file to be retrieved
  * @param callback {Function} Function to call when finalized, with the socket as a parameter
+ * @return {Ftp} this
  */
 Ftp.prototype.getGetSocket = function(path, callback) {
   var self = this;
@@ -447,6 +458,7 @@ Ftp.prototype.getGetSocket = function(path, callback) {
     };
     self.execute("retr " + path, cmdCallback);
   });
+  return this;
 };
 
 /**
@@ -456,6 +468,7 @@ Ftp.prototype.getGetSocket = function(path, callback) {
  * @param {String|Buffer} from Contents to be uploaded.
  * @param {String} to path for the remote destination.
  * @param {Function} callback Function to execute on error or success.
+ * @return {Ftp} this
  */
 Ftp.prototype.put = function(from, to, callback) {
   var self = this;
@@ -496,6 +509,7 @@ Ftp.prototype.put = function(from, to, callback) {
   } else {
     putReadable(from, to, from.size, callback);
   }
+  return this;
 };
 
 Ftp.prototype.getPutSocket = function(path, callback, doneCallback) {
@@ -533,6 +547,7 @@ Ftp.prototype.getPutSocket = function(path, callback, doneCallback) {
     };
     self.execute("stor " + path, putCallback);
   });
+  return this;
 };
 
 Ftp.prototype.getPasvSocket = function(callback) {
@@ -551,6 +566,7 @@ Ftp.prototype.getPasvSocket = function(callback) {
     socket.setTimeout(timeout || TIMEOUT);
     callback(null, socket);
   });
+  return this;
 };
 
 /**
@@ -579,6 +595,7 @@ Ftp.prototype.getPasvSocket = function(callback) {
  * @param filePath {String} Path to the file or directory to list
  * @param callback {Function} Function to call with the proper data when
  * the listing is finished.
+ * @return {Ftp} this
  */
 Ftp.prototype.ls = function(filePath, callback) {
   function entriesToList(err, entries) {
@@ -611,6 +628,7 @@ Ftp.prototype.ls = function(filePath, callback) {
       }
     });
   }
+  return this;
 };
 
 Ftp.prototype.rename = function(from, to, callback) {
@@ -621,6 +639,7 @@ Ftp.prototype.rename = function(from, to, callback) {
       callback(err, res);
     });
   });
+  return this;
 };
 
 Ftp.prototype.keepAlive = function() {
@@ -629,6 +648,7 @@ Ftp.prototype.keepAlive = function() {
     clearInterval(this._keepAliveInterval);
 
   this._keepAliveInterval = setInterval(self.raw.noop, IDLE_TIME);
+  return this;
 };
 
 Ftp.prototype.destroy = function() {
@@ -638,4 +658,5 @@ Ftp.prototype.destroy = function() {
   this.socket.destroy();
   this.features = null;
   this.authenticated = false;
+  return this;
 };

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -733,4 +733,28 @@ describe("jsftp test suite", function() {
       next();
     });
   });
+
+  it("Test method chaining", function(next) {
+    var count = 0,
+      ftp2 = ftp.auth(FTPCredentials.user, FTPCredentials.pass,
+        function(err, res) {
+          count += 1;
+          assert(!err, err);
+          assert.equal(res.code, 230, res);
+          assert.equal(count, 1);
+          ftp2.raw('pwd', function(err, res) {
+            count += 1;
+            assert(!err, err);
+            assert.equal(res.code, 257, res);
+            assert.equal(count, 2);
+          }).raw.cwd('..', function(err, res) {
+            count += 1;
+            assert(!err, err);
+            assert.equal(res.code, 250, res);
+            assert.equal(count, 3);
+            next();
+          });
+        });
+    assert(ftp2 instanceof Ftp);
+  });
 });


### PR DESCRIPTION
This PR extends the "raw" commands and the "helper" commands (```auth```, ```ls```, etc) by returning ```this``` instead of (an implicit) ```undefined```.

This allows for request calls to be chained together, as demonstrated in asylumfunk#1 .

Affected jsdocs have also been updated.