### PR TITLE
return boolean from hasFeat()

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -234,8 +234,7 @@ Ftp.prototype.parse = function(response, command) {
  * @returns {Boolean} Whether the current server has the feature
  */
 Ftp.prototype.hasFeat = function(feature) {
-  if (feature)
-    return this.features.indexOf(feature.toLowerCase()) > -1;
+  return !!feature && this.features.indexOf(feature.toLowerCase()) > -1;
 };
 
 /**

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -227,6 +227,10 @@ describe("jsftp test suite", function() {
       var feat = ftp.features[0];
       assert.ok(ftp.hasFeat(feat));
       assert.equal(false, ftp.hasFeat("madeup-feat"));
+      assert.equal(false, ftp.hasFeat());
+      assert.equal(false, ftp.hasFeat(null));
+      assert.equal(false, ftp.hasFeat(''));
+      assert.equal(false, ftp.hasFeat(0));
       next();
     });
   });


### PR DESCRIPTION
This updates `Ftp.prototype.hasFeat(feature)` to always return a boolean value, instead of `undefined` when passed a `falsey` parameter.

Corresponding tests have been included.

ref asylumfunk#2
