### PR TITLE
allow sending of arbitrary commands

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -26,7 +26,7 @@ var COMMANDS = [
   "abor", "pwd", "cdup", "feat", "noop", "quit", "pasv", "syst",
   // Commands with one or more parameters
   "cwd", "dele", "list", "mdtm", "mkd", "mode", "nlst", "pass", "retr", "rmd",
-  "rnfr", "rnto", "site", "stat", "stor", "type", "user", "pass", "xrmd", "opts",
+  "rnfr", "rnto", "site", "stat", "stor", "type", "user", "xrmd", "opts",
   // Extended features
   "chmod", "size"
 ];
@@ -75,7 +75,9 @@ var Ftp = module.exports = function(cfg) {
   // Generate generic methods from parameter names. they can easily be
   // overriden if we need special behavior. they accept any parameters given,
   // it is the responsability of the user to validate the parameters.
-  this.raw = {};
+  this.raw = function () {
+    return runCmd.apply(this, arguments);
+  }.bind(this);
   COMMANDS.forEach(function(cmd) {
     this.raw[cmd] = runCmd.bind(this, cmd);
   }, this);

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -687,4 +687,26 @@ describe("jsftp test suite", function() {
       });
     });
   });
+
+  it("Test raw method with PWD", function(next) {
+    ftp.raw('pwd', function(err, res) {
+      assert(!err, err);
+
+      var code = parseInt(res.code, 10);
+      assert.ok(code === 257, "Raw PWD command was not successful: " + res.text);
+
+      next();
+    });
+  });
+
+  it("Test raw method with HELP", function(next) {
+    ftp.raw('help', function(err, res) {
+      assert(!err, err);
+
+      var code = parseInt(res.code, 10);
+      assert.ok(code === 214, "Raw HELP command was not successful: " + res.text);
+
+      next();
+    });
+  });
 });


### PR DESCRIPTION
Currently, only commands which have been explicitly supported (by being included in the `COMMANDS[...]` array) can be called via `Ftp.raw`.

This PR extends the `Ftp.raw` object to allow arbitrary commands to be sent.

Instead of initializing `Ftp.raw` as an empty object, we initialize it as function, leveraging JavaScript's consideration of functions as first-class objects. We are still able to set and call member methods/properties as before, but we can also now invoke `Ftp.raw` directly. Internally, both `Ftp.raw(...)` and `Ftp.raw[cmd](...)` call the same function (`runCmd`) with the same scope (`Ftp`).

This allows for the following, perfectly compatible uses:

``` js
var client = new Ftp(options);
client.raw.pwd(callback);//as before
client.raw('pwd', callback);//new syntax
client.raw('HELP', callback);//previously unsupported
```

Users can now issue any remote command.

This PR also includes relevant tests (new syntax for an "old" command and new syntax for a "new" command). And of course, all previous tests using the old syntax still pass, as well.

The first commit here also removes a duplicate entry for the `pass` command in the `COMMANDS[...]` array.

Please let me know if you have any questions.
