### PR TITLE
preserve error reply codes during authentication failure

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -294,10 +294,9 @@ Ftp.prototype.auth = function(user, pass, callback) {
       self.raw.pass(pass, function(err, res) {
         self.authenticating = false;
 
-        if (err)
-          notifyAll(new Error("Login not accepted"));
-
-        if ([230, 202].indexOf(res.code) > -1) {
+        if (err) {
+          notifyAll(err);
+        } else if ([230, 202].indexOf(res.code) > -1) {
           self.authenticated = true;
           self.user = user;
           self.pass = pass;
@@ -310,7 +309,7 @@ Ftp.prototype.auth = function(user, pass, callback) {
       });
     } else {
       self.authenticating = false;
-      notifyAll(new Error("Login not accepted"));
+      notifyAll(err);
     }
   });
 };

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -218,6 +218,30 @@ describe("jsftp test suite", function() {
     next();
   });
 
+  it("test invalid username", function(next) {
+    this.timeout(10000);
+    ftp.auth(
+      FTPCredentials.user + '_invalid',
+      FTPCredentials.pass,
+      function(err, data) {
+        assert.equal(err.code, 530);
+        assert.equal(data, null);
+        next();
+    });
+  });
+
+  it("test invalid password", function(next) {
+    this.timeout(10000);
+    ftp.auth(
+      FTPCredentials.user,
+      FTPCredentials.pass + '_invalid',
+      function(err, data) {
+        assert.equal(err.code, 530);
+        assert.equal(data, null);
+        next();
+    });
+  });
+
   it("test getFeatures", function(next) {
     ftp.getFeatures(function(err, feats) {
       assert.ok(Array.isArray(feats));


### PR DESCRIPTION
This PR updates the `Ftp.auth` error handling to pass along the original error response; e.g. `530 Not logged in.`, instead of the generic `Login not accepted"`.

Previously, a new `Error` object was created and passed along to the callback. 

This allows for the disambiguation of authentication error replies (`500`, `501`, `503`, `421`) by preserving the original reply code and text from the server.

Corresponding test cases have been included.
- Note: These two new tests set timeouts of 10000ms, because the server hangs during invalid logins. This delay is slightly longer (~5010ms) than the default test case timeout (5000ms) and would cause the tests to otherwise fail.
