### PR TITLE
extend keepAlive to take an optional time period

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ ftp.rename(from, to, function(err, res) {
 });
 ```
 
-#### Ftp.keepAlive()
-Refreshes the interval thats keep the server connection active.
+#### Ftp.keepAlive([wait])
+Refreshes the interval thats keep the server connection active. `wait` is an optional time period (in milliseconds) to wait between intervals.
 
 You can find more usage examples in the [unit tests](https://github.com/sergi/jsftp/blob/master/test/jsftp_test.js). This documentation
 will grow as jsftp evolves.
@@ -217,8 +217,8 @@ In order to run coverage reports:
     make coverage
 
     Current overall coverage rate:
-      lines......: 92.1% (316 of 343 lines)
-      functions..: 91.0% (71 of 78 functions)
+      lines......: 95.5% (278 of 291 lines)
+      functions..: 100% (69 of 69 functions)
 
 
 Tests

--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -623,12 +623,12 @@ Ftp.prototype.rename = function(from, to, callback) {
   });
 };
 
-Ftp.prototype.keepAlive = function() {
+Ftp.prototype.keepAlive = function(wait) {
   var self = this;
   if (this._keepAliveInterval)
     clearInterval(this._keepAliveInterval);
 
-  this._keepAliveInterval = setInterval(self.raw.noop, IDLE_TIME);
+  this._keepAliveInterval = setInterval(self.raw.noop, wait || IDLE_TIME);
 };
 
 Ftp.prototype.destroy = function() {

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -733,4 +733,14 @@ describe("jsftp test suite", function() {
       next();
     });
   });
+
+  it("Test keep-alive with NOOP", function(next) {
+    this.timeout(10000);
+    ftp.keepAlive();
+    ftp.keepAlive(1000);
+    setTimeout(function() {
+      ftp.destroy();
+      next();
+    }, 5000);
+  });
 });


### PR DESCRIPTION
This allows `keepAlive` to take an optional parameter to configure the interval (default is still 30 seconds).

Test coverage has been added.

README documentation has been updated.

I've also updated the README's test coverage statistics, which have now hit 100% of functions tested!

```
=============================== Coverage summary ===============================
Statements   : 92.23% ( 285/309 )
Branches     : 77.84% ( 130/167 )
Functions    : 100% ( 69/69 )
Lines        : 95.53% ( 278/291 )
================================================================================
```
