### PR TITLE
Return from get if getGetSocket errors

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -420,7 +420,7 @@ Ftp.prototype.get = function(remotePath, localPath, callback) {
     callback = once(callback || NOOP);
     this.getGetSocket(remotePath, function(err, socket) {
       if (err) {
-        callback(err);
+        return callback(err);
       }
 
       var writeStream = fs.createWriteStream(localPath);


### PR DESCRIPTION
Currently, if an error is returned by `getGetSocket`, then `get` will still try to go ahead with the download. This can happen if an attempt is made to download a non-existent file, and will produce an exception such as:

```
/Users/sean.dwyer/ws/node_modules/jsftp/lib/jsftp.js:429
      socket.on('readable', function() {
             ^
TypeError: Cannot call method 'on' of undefined
    at /Users/sean.dwyer/ws/node_modules/jsftp/lib/jsftp.js:429:14
    at f (/Users/sean.dwyer/ws/node_modules/jsftp/node_modules/once/once.js:16:25)
    at Array.cmdCallback [as 1] (/Users/sean.dwyer/ws/node_modules/jsftp/lib/jsftp.js:461:23)
    at Ftp.parse (/Users/sean.dwyer/ws/node_modules/jsftp/lib/jsftp.js:249:13)
    at Ftp.parseResponse (/Users/sean.dwyer/ws/node_modules/jsftp/lib/jsftp.js:161:8)
    at Stream.<anonymous> (/Users/sean.dwyer/ws/node_modules/jsftp/lib/jsftp.js:132:24)
    at Stream.EventEmitter.emit (events.js:95:17)
    at ResponseParser.reemit (/Users/sean.dwyer/ws/node_modules/jsftp/node_modules/event-stream/node_modules/duplexer/index.js:70:25)
    at ResponseParser.EventEmitter.emit (events.js:95:17)
    at ResponseParser.<anonymous> (_stream_readable.js:746:14)
```
