### PR TITLE
Fixed error caused by passing a local dir to put()

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -511,6 +511,10 @@ Ftp.prototype.put = function(from, to, callback) {
         return callback(new Error("Local file doesn't exist."));
 
       fs.stat(from, function(err, stats) {
+
+        if (stats.isDirectory())
+            return callback(new Error("Local path cannot be a directory"));
+
         var totalSize = err ? 0 : stats.size;
         var read = fs.createReadStream(from, {
           bufferSize: 4 * 1024

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -389,6 +389,17 @@ describe("jsftp test suite", function() {
     });
   });
 
+  it("test passing a dir instead of file path to put should callback with error", function (next) {
+
+      var localUploadPath = ".";
+      var remoteFileName  = "directory_file_upload_should_fail.txt";
+
+      ftp.put(localUploadPath, remoteFileName, function(hadError) {
+          assert.ok(hadError);
+          next();
+    });
+  });
+
   it("test streaming put", function(next) {
     var readStream = Fs.createReadStream(__filename);
     var remoteFileName = "file_ftp_test.txt";


### PR DESCRIPTION
If the first parameter to 'put()' was a directory path, an unhandled exception would be thrown. This commit checks to see if the first parameter to 'put()' is a directory, and if it is, invokes the callback and an error.