### PR TITLE
Introduce connection timeout

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -114,13 +114,28 @@ Ftp.prototype._createSocket = function(port, host, firstAction) {
   if (this.socket && this.socket.destroy) this.socket.destroy();
 
   this.authenticated = false;
-  var socket = Net.createConnection(port, host, firstAction || NOOP);
+  var self = this;
+  var socket = Net.createConnection(port, host, function() {
+    socket.removeListener("timeout", connectionTimeout);
+    socket.setTimeout(0);
+    (firstAction || NOOP)();
+  });
+
   socket.on("connect", this.reemit("connect"));
   socket.on("timeout", this.reemit("timeout"));
+  socket.on("timeout", connectionTimeout);
+
+  if (this.connectionTimeout) {
+    socket.setTimeout(this.connectionTimeout);
+  }
 
   this._createStreams(socket);
 
   return socket;
+
+  function connectionTimeout(event) {
+    self.emit("connection-timeout");
+  }
 };
 
 Ftp.prototype._createStreams = function(socket) {


### PR DESCRIPTION
Hi Sergi,

I have added a concept of connection timeout to the library. This is useful if user wants to fail fast when connection can't be established, but still doesn't want to use same (short) socket timeout once connection is established.
I find this useful as I work in an environment with unreliable network, so I was given a number of addresses to FTP server and I need to try them in sequence, but I don't want to wait full OS socket timeout for connection attempt to fail.

Do you think this is useful enough to warrant a pull?

I am happy to update implementation if you have any concerns.

Cheers,
Dali