### PR TITLE
Added minimal support for FTP with TLS/SSL

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -10,6 +10,7 @@
 'use strict';
 
 var Net = require('net');
+var tls = require('tls');
 var EventEmitter = require('events').EventEmitter;
 var es = require('event-stream');
 var ResponseParser = require('ftp-response-parser');
@@ -117,13 +118,25 @@ Ftp.prototype._createSocket = function(port, host, firstAction) {
   }
 
   this.authenticated = false;
-  var socket = Net.createConnection(port, host, firstAction || NOOP);
-  socket.on('connect', this.reemit('connect'));
-  socket.on('timeout', this.reemit('timeout'));
+  var self = this;
+  var socket;
+
+  if(this.ssl){
+    socket = tls.connect(port,host,this.sslOptions,function(){
+	  //runt PROT command to specify that the data channel is secure
+      self.runCommand('prot p',function(){
+        self.reemit('connect');
+      });
+    });
+  }
+  else{
+    socket = Net.createConnection(port, host, firstAction || NOOP);
+    socket.on('connect', this.reemit('connect'));
+    socket.on('timeout', this.reemit('timeout'));
+  }
+
 
   this.pipeline = es.pipeline(socket, this.resParser);
-
-  var self = this;
   this.pipeline.on('data', function(data) {
     self.emit('data', data);
     self.parseResponse.call(self, data);
@@ -583,13 +596,22 @@ Ftp.prototype.pasvTimeout = function(socket, cb) {
 Ftp.prototype.getPasvSocket = function(callback) {
   var timeout = this.timeout;
   callback = once(callback || NOOP);
+  var self = this;
   this.execute('pasv', function(err, res) {
     if (err) return callback(err);
 
     getPasvPort(res.text, function(err, res) {
       if (err) return callback(err);
 
-      var socket = Net.createConnection(res.port, res.host);
+      var socket;
+      if(self.ssl){
+        socket = tls.connect(res.port,res.host,self.sslOptions,function(){
+          self.reemit('connect');
+        });
+      }
+      else{
+        socket = Net.createConnection(res.port, res.host);
+      }
       socket.setTimeout(timeout || TIMEOUT);
       callback(null, socket);
     });

--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -126,7 +126,7 @@ Ftp.prototype._createSocket = function(port, host, firstAction) {
 	  //runt PROT command to specify that the data channel is secure
       self.runCommand('prot p', function() {
         self.reemit('connect');
-        socket.on('timeout',)
+        //TODO timeout for tls connection?
       });
     });
   }

--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -121,11 +121,12 @@ Ftp.prototype._createSocket = function(port, host, firstAction) {
   var self = this;
   var socket;
 
-  if(this.ssl){
-    socket = tls.connect(port,host,this.sslOptions,function(){
+  if (this.ssl) {
+    socket = tls.connect(port, host, this.sslOptions, function() {
 	  //runt PROT command to specify that the data channel is secure
-      self.runCommand('prot p',function(){
+      self.runCommand('prot p', function() {
         self.reemit('connect');
+        socket.on('timeout',)
       });
     });
   }
@@ -604,8 +605,8 @@ Ftp.prototype.getPasvSocket = function(callback) {
       if (err) return callback(err);
 
       var socket;
-      if(self.ssl){
-        socket = tls.connect(res.port,res.host,self.sslOptions,function(){
+      if (self.ssl) {
+        socket = tls.connect(res.port, res.host, self.sslOptions, function() {
           self.reemit('connect');
         });
       }

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -66,7 +66,7 @@ var FTPCredentials = {
   pass: "12345"
 };
 
-var createLocal = false; //Set to false if you are using your own local FTP server
+var createLocal = true; //Set to false if you are using your own local FTP server
 
 function getRemotePath(path) {
   return Path.join('test', 'test_c9', path);


### PR DESCRIPTION
Tested only over FTP with implicit TLS/SSL encryption. 
Operations tested - ls(), get().