### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,5 @@
     "test": "mocha -R spec -t 5000",
     "clean": "rm -rf reports"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/sergi/jsftp/blob/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/