### PR TITLE
Replace all occurences of Ftp.raw[command] with Ftp.raw(command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ callback, in the form of an object that contains two properties: `code`, which
 is the response code of the FTP operation, and `text`, which is the complete
 text of the response.
 
-Raw (or native) commands are accessible in the form `Ftp.raw["command"](params, callback)`
+Raw (or native) commands are accessible in the form `Ftp.raw(command, params, callback)`
 
 Thus, a command like `QUIT` will be called like this:
 
 ```javascript
-Ftp.raw.quit(function(err, data) {
+Ftp.raw("quit", function(err, data) {
     if (err) return console.error(err);
 
     console.log("Bye!");
@@ -51,7 +51,7 @@ Ftp.raw.quit(function(err, data) {
 and a command like `MKD` (make directory), which accepts parameters, looks like this:
 
 ```javascript
-Ftp.raw.mkd("/new_dir", function(err, data) {
+Ftp.raw("mkd", "/new_dir", function(err, data) {
     if (err) return console.error(err);
 
     console.log(data.text); // Show the FTP response text to the user
@@ -101,7 +101,7 @@ Contains the system identification string for the remote FTP server.
 
 ### Methods
 
-#### Ftp.raw(command, callback)
+#### Ftp.raw(command, [...args], callback)
 With the `raw` method you can send any FTP command to the server. The method accepts a callback
 with the signature `err, data`, in which `err` is the error response coming
 from the server (usually a 4xx or 5xx error code) and the data is an object

--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -297,9 +297,9 @@ Ftp.prototype.getFeatures = function(callback) {
   }
 
   var self = this;
-  this.raw.feat(function(err, response) {
+  this.raw('feat', function(err, response) {
     self.features = err ? [] : self._parseFeats(response.text);
-    self.raw.syst(function(err, res) {
+    self.raw('syst', function(err, res) {
       if (!err && res.code === 215) {
         self.system = res.text.toLowerCase();
       }
@@ -331,13 +331,13 @@ Ftp.prototype.auth = function(user, pass, callback) {
   }
 
   this.authenticating = true;
-  self.raw.user(user, function(err, res) {
+  self.raw('user', user, function(err, res) {
     if (err || [230, 331, 332].indexOf(res.code) === -1) {
       self.authenticating = false;
       callback(err);
       return;
     }
-    self.raw.pass(pass, function(err, res) {
+    self.raw('pass', pass, function(err, res) {
       self.authenticating = false;
 
       if (err) {
@@ -346,11 +346,11 @@ Ftp.prototype.auth = function(user, pass, callback) {
         self.authenticated = true;
         self.user = user;
         self.pass = pass;
-        self.raw.type('I', function() {
+        self.raw('type', 'I', function() {
           callback(undefined, res);
         });
       } else if (res.code === 332) {
-        self.raw.acct(''); // ACCT not really supported
+        self.raw('acct', ''); // ACCT not really supported
       }
     });
   });
@@ -363,7 +363,7 @@ Ftp.prototype.setType = function(type, callback) {
   }
 
   var self = this;
-  this.raw.type(type, function(err, data) {
+  this.raw('type', type, function(err, data) {
     if (!err) {
       self.type = type;
     }
@@ -715,7 +715,7 @@ Ftp.prototype.ls = function(filePath, callback) {
     this.list(filePath, entriesToList);
   } else {
     var self = this;
-    this.raw.stat(filePath, function(err, data) {
+    this.raw('stat', filePath, function(err, data) {
       // We might be connected to a server that doesn't support the
       // 'STAT' command, which is set as default. We use 'LIST' instead,
       // and we set the variable `useList` to true, to avoid extra round
@@ -737,11 +737,11 @@ Ftp.prototype.ls = function(filePath, callback) {
 
 Ftp.prototype.rename = function(from, to, callback) {
   var self = this;
-  this.raw.rnfr(from, function(err) {
+  this.raw('rnfr', from, function(err) {
     if (err) {
       return callback(err);
     }
-    self.raw.rnto(to, callback);
+    self.raw('rnto', to, callback);
   });
 };
 
@@ -751,7 +751,7 @@ Ftp.prototype.keepAlive = function(wait) {
     clearInterval(this._keepAliveInterval);
   }
 
-  this._keepAliveInterval = setInterval(self.raw.noop, wait || IDLE_TIME);
+  this._keepAliveInterval = setInterval(self.raw.bind(self, 'noop'), wait || IDLE_TIME);
 };
 
 Ftp.prototype.destroy = function() {

--- a/test/jsftp_test.js
+++ b/test/jsftp_test.js
@@ -212,7 +212,7 @@ describe('jsftp test suite', function() {
   });
 
   it('test print working directory', function(next) {
-    ftp.raw.pwd(function(err, res) {
+    ftp.raw('pwd', function(err, res) {
       assert(!err, err);
 
       var code = parseInt(res.code, 10);
@@ -223,13 +223,13 @@ describe('jsftp test suite', function() {
   });
 
   it('test switch CWD', function(next) {
-    ftp.raw.cwd(remoteCWD, function(err, res) {
+    ftp.raw('cwd', remoteCWD, function(err, res) {
       assert.ok(!err, err);
 
       var code = parseInt(res.code, 10);
       assert.ok(code === 200 || code === 250, 'CWD command was not successful');
 
-      ftp.raw.pwd(function(err, res) {
+      ftp.raw('pwd', function(err, res) {
         assert.ok(!err, err);
 
         var code = parseInt(res.code, 10);
@@ -241,7 +241,7 @@ describe('jsftp test suite', function() {
   });
 
   it('test switch to unexistent CWD', function(next) {
-    ftp.raw.cwd('/unexistentDir/', function(err, res) {
+    ftp.raw('cwd', '/unexistentDir/', function(err, res) {
       var code = parseInt(res.code, 10);
       assert.ok(!!err);
       assert.equal(code, 550, 'A (wrong) CWD command was successful. It should have failed');
@@ -250,7 +250,7 @@ describe('jsftp test suite', function() {
   });
 
   it('test switch to unexistent CWD contains special string', function (next) {
-    ftp.raw.cwd('/unexistentDir/user', function (err, res) {
+    ftp.raw('cwd', '/unexistentDir/user', function (err, res) {
       var code = parseInt(res.code, 10);
       assert.equal(code, 550);
       next();
@@ -275,11 +275,11 @@ describe('jsftp test suite', function() {
   });
 
   it('test ftp node stat', function(next) {
-    ftp.raw.pwd(function(err, res) {
+    ftp.raw('pwd', function(err, res) {
       assert.ok(!err);
       var parent = new RegExp('.*"(.*)".*').exec(res.text)[1];
       var path = Path.resolve(parent + '/' + remoteCWD);
-      ftp.raw.stat(path, function(err, res) {
+      ftp.raw('stat', path, function(err, res) {
         assert.ok(!err, res);
         assert.ok(res);
 
@@ -291,11 +291,11 @@ describe('jsftp test suite', function() {
 
   it('test create and delete a directory', function(next) {
     var newDir = remoteCWD + '/ftp_test_dir';
-    ftp.raw.mkd(newDir, function(err, res) {
+    ftp.raw('mkd', newDir, function(err, res) {
       assert.ok(!err);
       assert.equal(res.code, 257);
 
-      ftp.raw.rmd(newDir, function(err, res) {
+      ftp.raw('rmd', newDir, function(err, res) {
         assert.ok(!err);
         next();
       });
@@ -304,11 +304,11 @@ describe('jsftp test suite', function() {
 
   it('test create and delete a directory containing a space', function(next) {
     var newDir = remoteCWD + '/ftp test dür';
-    ftp.raw.mkd(newDir, function(err, res) {
+    ftp.raw('mkd', newDir, function(err, res) {
       assert.ok(!err);
       assert.equal(res.code, 257);
 
-      ftp.raw.rmd(newDir, function(err, res) {
+      ftp.raw('rmd', newDir, function(err, res) {
         assert.ok(!err);
         next();
       });
@@ -326,7 +326,7 @@ describe('jsftp test suite', function() {
         assert.equal(buffer.length,
                      Fs.statSync(Path.join(process.cwd(), 'test/jsftp_test.js')).size);
 
-        ftp.raw.dele(filePath, function(err, data) {
+        ftp.raw('dele', filePath, function(err, data) {
           assert.ok(!err);
           next();
         });
@@ -348,7 +348,7 @@ describe('jsftp test suite', function() {
       assert.equal(data.action, 'put');
       assert.ok(typeof data.transferred, 'number');
 
-      ftp.raw.dele(filePath, function(err, data) {
+      ftp.raw('dele', filePath, function(err, data) {
         assert.ok(!err);
         next();
       });
@@ -377,7 +377,7 @@ describe('jsftp test suite', function() {
       var originalFileSize = Fs.statSync(__filename).size;
       assert.equal(uploadedFileSize, originalFileSize);
 
-      ftp.raw.dele(filePath, function(err, data) {
+      ftp.raw('dele', filePath, function(err, data) {
         assert.ok(!err);
         next();
       });
@@ -398,7 +398,7 @@ describe('jsftp test suite', function() {
 
           assert.equal(buffer.length, Fs.statSync(__filename).size);
 
-          ftp.raw.dele(to, function(err, data) {
+          ftp.raw('dele', to, function(err, data) {
             assert.ok(!err);
             next();
           });
@@ -475,7 +475,7 @@ describe('jsftp test suite', function() {
       socket.on('close', function() {
         assert.equal(buffer.length, counter);
 
-        ftp.raw.dele(remotePath, function(err, data) {
+        ftp.raw('dele', remotePath, function(err, data) {
           assert.ok(!err);
           next();
         });
@@ -497,7 +497,7 @@ describe('jsftp test suite', function() {
     }, function(err, res) {
       assert.ok(!err, err);
 
-      ftp.raw.dele(remotePath, function(err, data) {
+      ftp.raw('dele', remotePath, function(err, data) {
         assert.ok(!err);
         next();
       });
@@ -518,7 +518,7 @@ describe('jsftp test suite', function() {
   it('test get fileList array', function(next) {
     var file1 = 'testfile.txt';
 
-    ftp.raw.cwd(getRemoteFixturesPath(''), function() {
+    ftp.raw('cwd', getRemoteFixturesPath(''), function() {
       ftp.ls('.', function(err, res) {
         assert.ok(!err, err);
         assert.ok(Array.isArray(res));
@@ -537,13 +537,13 @@ describe('jsftp test suite', function() {
 
   it('test reconnect', function(next) {
     this.timeout(10000);
-    ftp.raw.pwd(function(err, res) {
+    ftp.raw('pwd', function(err, res) {
       if (err) {
         throw err;
       }
 
       ftp.socket.destroy();
-      ftp.raw.quit(function(err, res) {
+      ftp.raw('quit', function(err, res) {
         if (err) {
           throw err;
         }
@@ -763,7 +763,7 @@ describe('jsftp test suite', function() {
   it.skip('test listing a folder containing special UTF characters', function(next) {
     var dirName = unorm.nfc('_éàèùâêûô_');
     var newDir = Path.join(remoteCWD, dirName);
-    ftp.raw.mkd(newDir, function(err, res) {
+    ftp.raw('mkd', newDir, function(err, res) {
       assert.ok(!err);
       assert.equal(res.code, 257);
       var list = Fs.readdirSync(Path.join(__dirname, 'fixtures'));


### PR DESCRIPTION
And fix the README signature definition of `Ftp.raw()`.

This should get rid of all the deprecation warnings.
