### PR TITLE
feat(core) add support for implicit TLS

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -14,6 +14,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var fs = require('fs');
 var combine = require('stream-combiner');
+var tls = require('tls');
 
 var ResponseParser = require('ftp-response-parser');
 var ListingParser = require('parse-listing');
@@ -76,6 +77,7 @@ var Ftp = module.exports = function(cfg) {
   this.port = cfg.port || FTP_PORT;
   this.user = cfg.user || 'anonymous';
   this.pass = cfg.pass || '@anonymous';
+  this.implicit = cfg.implicit || false;
   // True if the server doesn't support the `stat` command. Since listing a
   // directory or retrieving file properties is quite a common operation, it is
   // more efficient to avoid the round-trip to the server.
@@ -125,7 +127,8 @@ Ftp.prototype._createSocket = function(port, host, firstAction) {
   this.resParser = new ResponseParser();
 
   this.authenticated = false;
-  this.socket = Net.createConnection(port, host, firstAction || NOOP);
+  var connectFunction = this.implicit ? tls.connect : Net.createConnection;    
+  this.socket = connectFunction(port, host, firstAction || NOOP);
   this.socket.on('connect', this.reemit('connect'));
   this.socket.on('timeout', this.reemit('timeout'));
 
@@ -654,7 +657,8 @@ Ftp.prototype.getPasvSocket = function(callback) {
       return callback(new Error('Bad passive host/port combination'));
     }
 
-    var socket = self._pasvSocket = Net.createConnection(options);
+    var connectFunction = this.implicit ? tls.connect : Net.createConnection;
+    var socket = self._pasvSocket = connectFunction(options);
     socket.setTimeout(self.timeout || TIMEOUT);
     socket.once('close', function() {
       self._pasvSocket = undefined;


### PR DESCRIPTION
Use `tls.connect` instead of `Net.createConnection` if user adds `implicit` option as a config option.