### PR TITLE
emit progress event for put Buffer

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -563,7 +563,35 @@ Ftp.prototype.put = function(from, to, callback) {
   if (from instanceof Buffer) {
     this.getPutSocket(to, function(err, socket) {
       if (!err) {
-        socket.end(from);
+        var pointer = 0;
+        var SLICE = 1024*1024;
+        var done = false;
+
+        socket.write(from.slice(0,SLICE));
+        pointer = SLICE;
+        socket.on("drain", () => {
+
+          if(from.length > pointer+SLICE) {
+            var newBuf = from.slice(pointer, pointer+SLICE);
+            pointer += SLICE;
+          }
+          else {
+            var newBuf = from.slice(pointer);
+            done = true;
+          }
+          socket.write(newBuf);
+
+          self.emit("progress", {
+            filename: "BUFFER",
+            action: "put",
+            transferred: pointer,
+            total: from.length
+          });
+
+          if(done) {
+            socket.end();
+          }
+        })
       }
     }, callback);
   } else if (typeof from === 'string') {


### PR DESCRIPTION
Hi,
I had the use case of putting a >30 MB Buffer to a server and there was no progress event emitted. 
So I added a quick fix for this. Maybe you would like to add this to jsftp.