### PR TITLE
Reemit "close" and "end" on socket connection

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -103,6 +103,9 @@ Ftp.prototype._createSocket = function(port, host, firstAction = NOOP) {
     : createConnection(port, host, firstAction);
   this.socket.on("connect", this.reemit("connect"));
   this.socket.on("timeout", this.reemit("timeout"));
+  
+  this.socket.on("close", this.reemit("close"));
+  this.socket.on("end", this.reemit("end"));
 
   this.pipeline = combine(this.socket, this.resParser);
 


### PR DESCRIPTION
To handle an invalid port I need to listen either to the `close` or to the `end` event during the connection process.
The `timeout` event can not be used for such a case: `Emitted if the socket times out from inactivity. This is only to notify that the socket has been idle.` (https://nodejs.org/api/net.html#net_event_timeout)