### PR TITLE
Fixed forced paused flowMode issue. 

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -458,6 +458,7 @@ Ftp.prototype.get = function(remotePath, localPath, callback = NOOP) {
           action: "get",
           socket: socket
         });
+      	socket.read();
       });
 
       // This ensures that any expected outcome is handled. There is no
@@ -545,6 +546,7 @@ Ftp.prototype.put = function(from, destination, callback) {
         socket: from,
         totalSize
       });
+      from.read();
     });
 
     this.getPutSocket(from, to, callback);


### PR DESCRIPTION
By using the readable event the paused flowMode is forced upon the stream, even though the use of pipe() later on.
By explicitly calling stream.read() on the readable event the pipe will function normally.

This will fix issues #284