### PR TITLE
Expand check for readable stream to include streams that aren't stric…

### DIFF
--- a/lib/jsftp.js
+++ b/lib/jsftp.js
@@ -39,6 +39,15 @@ const expectedMarks = {
 const RE_PASV = /([-\d]+,[-\d]+,[-\d]+,[-\d]+),([-\d]+),([-\d]+)/;
 const FTP_NEWLINE = /\r\n|\n/;
 
+function isReadableStream(stream) {
+  return stream !== null &&
+    typeof stream === 'object' &&
+    typeof stream.pipe === 'function' &&
+    stream.readable !== false &&
+    typeof stream._read === 'function' &&
+    typeof stream._readableState === 'object';
+}
+
 function runCmd(name, ...params) {
   let callback = NOOP;
   let completeCmd = name + " ";
@@ -565,7 +574,7 @@ Ftp.prototype.put = function(from, destination, callback) {
       const totalSize = err ? 0 : stats.size;
       putReadable(fs.createReadStream(from), destination, totalSize);
     });
-  } else if (from instanceof stream.Readable) {
+  } else if (isReadableStream(from)) {
     putReadable(from, destination, 0);
   } else {
     callback(
@@ -604,7 +613,7 @@ Ftp.prototype.getPutSocket = function(from, path, next) {
         this.pasvTimeout(socket, next);
         if (from instanceof Buffer) {
           socket.end(from);
-        } else if (from instanceof stream.Readable) {
+        } else if (isReadableStream(from)) {
           from.pipe(socket);
         }
       } else {


### PR DESCRIPTION
…tly stream.Readable.

An example of such scenario would be using the [Request library](https://github.com/request/request) , which returns streams but would not pass the current check for stream.Readable. 